### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -593,6 +593,9 @@ FodyWeavers.xsd
 *.msm
 *.msp
 
+# MacOS automatically added files
+.DS_Store
+
 # JetBrains Rider
 *.sln.iml
 


### PR DESCRIPTION
Updated gitignore to ignore metadate files for MacOS file management